### PR TITLE
Use formula in core instead of one in versions

### DIFF
--- a/arm-elf-binutils.rb
+++ b/arm-elf-binutils.rb
@@ -5,7 +5,7 @@ class ArmElfBinutils < Formula
   url 'http://ftp.gnu.org/gnu/binutils/binutils-2.23.tar.gz'
   sha256 '7909a08eabdbaac0f7a22e9ede82a66ba70acd50629b045e705af864eef10b65'
 
-  depends_on 'gcc49' => :build
+  depends_on 'gcc@4.9' => :build
 
   def install
     ENV['CC'] = '/usr/local/bin/gcc-4.9'

--- a/i386-elf-binutils.rb
+++ b/i386-elf-binutils.rb
@@ -5,7 +5,7 @@ class I386ElfBinutils < Formula
   url 'http://ftp.gnu.org/gnu/binutils/binutils-2.23.tar.gz'
   sha256 '7909a08eabdbaac0f7a22e9ede82a66ba70acd50629b045e705af864eef10b65'
 
-  depends_on 'gcc49' => :build
+  depends_on 'gcc@4.9' => :build
 
   def install
     ENV['CC'] = '/usr/local/bin/gcc-4.9'

--- a/x64-elf-binutils.rb
+++ b/x64-elf-binutils.rb
@@ -5,7 +5,7 @@ class X64ElfBinutils < Formula
   url 'http://ftp.gnu.org/gnu/binutils/binutils-2.23.tar.gz'
   sha256 '7909a08eabdbaac0f7a22e9ede82a66ba70acd50629b045e705af864eef10b65'
 
-  depends_on 'gcc49' => :build
+  depends_on 'gcc@4.9' => :build
 
   def install
     ENV['CC'] = '/usr/local/bin/gcc-4.9'


### PR DESCRIPTION
Formulae in `homebrew/versions` are deprecated and some of them migrated to core tap.

This is needed to resolve redox-os/redox#871.